### PR TITLE
Added missing 'rimraf' to devDeps on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
-    "file-loader": "^0.8.5"
+    "file-loader": "^0.8.5",
+    "rimraf": "^2.6.1"
   }
 }


### PR DESCRIPTION
Was trying to build the example project and noticed it was failing cause the 'rimraf' package was missing.